### PR TITLE
Upgrade GitHub Actions workflow to latest versions.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,18 +5,21 @@ on:
     branches:
       - main
 
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3.4"
           bundler-cache: true
-      - run: bundle install
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
- Upgrade actions/checkout from v2 to v4 (Node 20, EOL Node 16 removed)
- Remove redundant bundle install (bundler-cache: true handles it)
- Add concurrency group to cancel in-flight deployments on new push