### PR TITLE
Add AI Readiness Self-Assessment page

### DIFF
--- a/.features/email-integration/CODING-SPEC-email-integration.md
+++ b/.features/email-integration/CODING-SPEC-email-integration.md
@@ -1,0 +1,75 @@
+# CODING SPEC: Email Integration — Contact Form
+
+## Context
+
+The site is a **static site on GitHub Pages** built with Bridgetown. There is no server-side processing available. The contact form in `src/_components/contact_form.liquid` currently has no `action` or submission handler — it does not send data anywhere.
+
+This spec covers the viable approaches for triggering an email when a user completes the Contact Us form.
+
+---
+
+## Option 1: Formspree (Recommended — simplest)
+
+**How it works:** Point the form `action` at a Formspree endpoint. They receive the submission and forward it to your email.
+
+**Steps:**
+1. Sign up at [formspree.io](https://formspree.io) (free tier: 50 submissions/month)
+2. Create a new form → get an endpoint like `https://formspree.io/f/xyzabc`
+3. Update `contact_form.liquid`:
+   - Add `action="https://formspree.io/f/xyzabc"` and `method="POST"` to the `<form>` tag
+   - Add a hidden `<input type="hidden" name="_subject" value="New Contact Form Submission">` for the email subject
+4. Remove the existing JS submit handler (if any) or let the form POST natively
+5. Formspree sends an email to `rupakg@gmail.com` on every submission
+
+**Pros:** Zero backend code, free, works out of the box, spam filtering included
+**Cons:** Formspree branding on free tier, 50/month submission limit
+
+---
+
+## Option 2: Web3Forms (Free, no monthly limit)
+
+Same approach as Formspree but no submission limits on the free plan.
+
+**Steps:**
+1. Sign up at [web3forms.com](https://web3forms.com), get an access key
+2. Add `action="https://api.web3forms.com/submit"` and `method="POST"` to the `<form>` tag
+3. Add `<input type="hidden" name="access_key" value="YOUR_KEY">` inside the form
+4. Submissions arrive in your inbox immediately
+
+**Pros:** Free with no submission limits, simple integration
+**Cons:** Less control over email formatting compared to EmailJS
+
+---
+
+## Option 3: EmailJS (client-side, no form redirect)
+
+**How it works:** JS sends the email directly from the browser — the page does not redirect after submission, enabling a custom in-page success state.
+
+**Steps:**
+1. Sign up at [emailjs.com](https://emailjs.com) (free: 200 emails/month)
+2. Create an email service (Gmail) + email template in the EmailJS dashboard
+3. Add the EmailJS SDK to `src/_components/head.liquid`
+4. Replace the form's submit handler in `frontend/javascript/index.js` with an `emailjs.send(...)` call
+5. Show a custom success message in the UI without page reload
+
+**Pros:** Full control over UX, no redirect, custom in-page success state
+**Cons:** API key visible in client-side JS (mitigated by domain allowlisting in the EmailJS dashboard); 200 emails/month on free tier
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `src/_components/contact_form.liquid` | Add `action`, `method`, and hidden input fields to the `<form>` tag (Options 1 & 2), or keep as-is and wire up JS handler (Option 3) |
+| `src/_components/head.liquid` | Add EmailJS SDK `<script>` tag (Option 3 only) |
+| `frontend/javascript/index.js` | Add form `submit` event listener and `emailjs.send()` call (Option 3 only) |
+
+---
+
+## Recommendation
+
+Given the existing site is on GitHub Pages with no backend:
+
+- **Start with Web3Forms or Formspree** — a 2-file change (form action + hidden input), live in minutes.
+- **Upgrade to EmailJS** later if a polished in-page success state (no redirect) is needed.

--- a/frontend/styles/ai_readiness.css
+++ b/frontend/styles/ai_readiness.css
@@ -1,0 +1,523 @@
+/* ============================================================
+   AI Readiness Self-Assessment Page
+   ============================================================ */
+
+/* === HERO === */
+.ai-readiness-hero {
+  padding-top: calc(80px + 3rem);
+  padding-bottom: 4rem;
+  background: linear-gradient(135deg, var(--kotai-slate) 0%, #8a94b8 100%);
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+}
+
+@media (min-width: 1024px) {
+  .ai-readiness-hero {
+    padding-top: calc(80px + 4rem);
+    padding-bottom: 5rem;
+  }
+}
+
+.ai-readiness-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 50%, rgba(255, 203, 181, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(255, 203, 181, 0.1) 0%, transparent 40%);
+  pointer-events: none;
+}
+
+.ai-readiness-hero-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.ai-readiness-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 9999px;
+  padding: 0.375rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: white;
+  letter-spacing: 0.02em;
+  margin-bottom: 1.5rem;
+}
+
+.ai-readiness-badge-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: var(--kotai-peach);
+}
+
+.ai-readiness-hero h1 {
+  font-family: var(--font-serif);
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: white;
+  line-height: 1.15;
+  margin-bottom: 1.25rem;
+}
+
+@media (min-width: 768px) { .ai-readiness-hero h1 { font-size: 2.75rem; } }
+@media (min-width: 1024px) { .ai-readiness-hero h1 { font-size: 3rem; } }
+
+.ai-readiness-hero p {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.65;
+  max-width: 560px;
+  margin: 0 auto 2rem;
+}
+
+@media (min-width: 768px) { .ai-readiness-hero p { font-size: 1.0625rem; } }
+
+.ai-readiness-hero p small {
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.ai-readiness-hero-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.ai-readiness-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.ai-readiness-meta-item svg,
+.ai-readiness-meta-item i[data-lucide] {
+  width: 0.9375rem;
+  height: 0.9375rem;
+  flex-shrink: 0;
+  color: var(--kotai-peach);
+}
+
+/* === ASSESSMENT SECTION === */
+.ai-readiness-section {
+  padding: 3rem 1rem 5rem;
+  background: var(--kotai-off-white);
+}
+
+@media (min-width: 768px) { .ai-readiness-section { padding: 4rem 1.5rem 6rem; } }
+
+.ai-readiness-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* === QUIZ CARD === */
+.ar-card {
+  background: white;
+  border: 1.5px solid var(--kotai-peach-dark);
+  border-radius: 1.25rem;
+  box-shadow: 0 8px 30px rgba(255, 184, 159, 0.25);
+  overflow: hidden;
+}
+
+/* Card header bar */
+.ar-card-header {
+  padding: 1.5rem 1.75rem;
+  background: linear-gradient(135deg, var(--kotai-peach), var(--kotai-peach-dark));
+  color: var(--kotai-charcoal);
+}
+
+@media (min-width: 640px) { .ar-card-header { padding: 2rem 2.25rem; } }
+
+.ar-card-header h2 {
+  font-family: var(--font-serif);
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+  margin: 0 0 0.5rem;
+}
+
+@media (min-width: 640px) { .ar-card-header h2 { font-size: 1.5rem; } }
+
+.ar-header-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ar-header-meta p {
+  margin: 0;
+  opacity: 0.75;
+  font-size: 0.875rem;
+  color: var(--kotai-charcoal);
+}
+
+/* Card body */
+.ar-card-body {
+  padding: 1.5rem 1.75rem;
+}
+
+@media (min-width: 640px) { .ar-card-body { padding: 2rem 2.25rem; } }
+
+/* Meta row: section badge + question count */
+.ar-meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.ar-badge {
+  display: inline-block;
+  padding: 0.3125rem 0.875rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(255, 203, 181, 0.25);
+  color: var(--kotai-charcoal);
+  border: 1px solid rgba(255, 184, 159, 0.5);
+}
+
+/* Progress bar */
+.ar-progress {
+  height: 8px;
+  background: #f1f5f9;
+  border-radius: 9999px;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.ar-progress-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--kotai-peach), var(--kotai-peach-dark));
+  border-radius: 9999px;
+  transition: width 0.3s ease;
+}
+
+/* Question */
+.ar-question {
+  font-family: var(--font-serif);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--kotai-charcoal);
+  line-height: 1.45;
+  margin: 0 0 1.25rem;
+}
+
+@media (min-width: 640px) { .ar-question { font-size: 1.125rem; } }
+
+/* Options grid */
+.ar-options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+@media (min-width: 540px) { .ar-options { grid-template-columns: 1fr 1fr; } }
+
+.ar-option-btn {
+  border: 1px solid rgba(51, 51, 51, 0.12);
+  border-radius: 0.875rem;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  cursor: pointer;
+  background: linear-gradient(180deg, #ffffff 0%, #fafbff 100%);
+  transition: all 0.2s ease;
+  color: var(--kotai-charcoal);
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  min-height: 3.5rem;
+  font-family: var(--font-sans);
+}
+
+.ar-option-btn:hover {
+  border-color: var(--kotai-peach-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(255, 184, 159, 0.2);
+  background: linear-gradient(180deg, #ffffff 0%, #fff5f0 100%);
+}
+
+.ar-option-btn:focus-visible {
+  outline: 3px solid rgba(255, 203, 181, 0.5);
+  outline-offset: 2px;
+}
+
+.ar-option-btn.selected {
+  border-color: var(--kotai-peach-dark);
+  box-shadow: 0 0 0 3px rgba(255, 203, 181, 0.35);
+  background: linear-gradient(180deg, #fff5f0 0%, #ffe8dc 100%);
+}
+
+.ar-option-score {
+  width: 1.625rem;
+  height: 1.625rem;
+  border-radius: 9999px;
+  background: rgba(255, 203, 181, 0.35);
+  color: var(--kotai-charcoal);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 800;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.ar-option-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 1.625rem;
+}
+
+.ar-option-text {
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--kotai-charcoal);
+}
+
+/* Hint */
+.ar-hint {
+  font-size: 0.875rem;
+  color: var(--kotai-slate);
+  margin-bottom: 1rem;
+}
+
+/* Nav actions */
+.ar-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Buttons */
+.ar-btn {
+  border: 0;
+  border-radius: 0.625rem;
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: all 0.2s ease;
+}
+
+.ar-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+.ar-btn-primary {
+  background: var(--kotai-peach);
+  color: var(--kotai-charcoal);
+}
+
+.ar-btn-primary:hover:not(:disabled) {
+  background: var(--kotai-peach-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(255, 184, 159, 0.4);
+}
+
+.ar-btn-secondary {
+  background: var(--kotai-off-white);
+  color: var(--kotai-charcoal);
+  border: 1px solid rgba(51, 51, 51, 0.14);
+}
+
+.ar-btn-secondary:hover:not(:disabled) {
+  background: #fff0ea;
+  border-color: var(--kotai-peach-dark);
+}
+
+.ar-btn-peach {
+  background: var(--kotai-peach);
+  color: var(--kotai-charcoal);
+}
+
+.ar-btn-peach:hover {
+  background: var(--kotai-peach-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(255, 203, 181, 0.4);
+}
+
+/* === RESULT VIEW === */
+.ar-result-card {
+  border-radius: 0.875rem;
+  border: 1.5px solid var(--kotai-peach-dark);
+  box-shadow: 0 6px 24px rgba(255, 184, 159, 0.2);
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+  background: var(--kotai-off-white);
+  color: var(--kotai-charcoal);
+}
+
+.ar-result-ready, .ar-result-emerging, .ar-result-explore { }
+
+.ar-result-status-badge {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin: 0 0 0.75rem;
+}
+
+.ar-result-ready .ar-result-status-badge {
+  background: #d1fae5;
+  border-color: #6ee7b7;
+  color: #065f46;
+}
+
+.ar-result-emerging .ar-result-status-badge {
+  background: #ffe4cc;
+  border-color: #fdba74;
+  color: #9a3412;
+}
+
+.ar-result-explore .ar-result-status-badge {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+
+.ar-score-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid rgba(51, 51, 51, 0.1);
+  border-radius: 0.625rem;
+  background: white;
+}
+
+.ar-score-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+  line-height: 1.35;
+}
+
+.ar-score-value {
+  font-size: 1.125rem;
+  font-weight: 800;
+  color: var(--kotai-charcoal);
+  white-space: nowrap;
+}
+
+.ar-result-card h2 {
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+  margin: 0 0 0.5rem;
+}
+
+.ar-result-card p {
+  margin: 0 0 0.5rem;
+  line-height: 1.55;
+  font-size: 0.9375rem;
+  color: var(--kotai-charcoal);
+}
+
+.ar-result-card p strong {
+  color: var(--kotai-charcoal);
+}
+
+.ar-section-scores {
+  margin-top: 1rem;
+  border-top: 1px dashed rgba(51, 51, 51, 0.15);
+  padding-top: 0.75rem;
+}
+
+.ar-section-scores strong {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+}
+
+.ar-section-scores ul {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ar-section-scores li {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px dashed rgba(51, 51, 51, 0.1);
+  padding: 0.5rem 0;
+  font-size: 0.9rem;
+  color: var(--kotai-charcoal);
+}
+
+/* CTA box at end of result */
+.ar-result-cta {
+  margin-top: 1rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(51, 51, 51, 0.1);
+  border-radius: 0.875rem;
+  background: white;
+}
+
+.ar-result-cta h3 {
+  font-family: var(--font-serif);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+  margin: 0 0 0.5rem;
+  line-height: 1.35;
+}
+
+.ar-result-cta p {
+  margin: 0 0 1rem;
+  color: var(--kotai-slate);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.ar-result-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}

--- a/frontend/styles/ai_readiness.css
+++ b/frontend/styles/ai_readiness.css
@@ -113,6 +113,92 @@
   color: var(--kotai-peach);
 }
 
+/* === HOME PAGE BANNER === */
+.ar-banner {
+  background: linear-gradient(135deg, rgba(255, 203, 181, 0.25) 0%, rgba(255, 184, 159, 0.15) 100%);
+  border-top: 1px solid rgba(255, 184, 159, 0.35);
+  border-bottom: 1px solid rgba(255, 184, 159, 0.35);
+  padding: 3rem 1.5rem;
+}
+
+@media (min-width: 1024px) { .ar-banner { padding: 4rem 3rem; } }
+
+.ar-banner-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .ar-banner-inner {
+    flex-direction: row;
+    text-align: left;
+    gap: 2rem;
+  }
+}
+
+.ar-banner-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 1rem;
+  background: var(--kotai-peach);
+  flex-shrink: 0;
+}
+
+.ar-banner-icon i[data-lucide] {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--kotai-charcoal);
+}
+
+.ar-banner-content {
+  flex: 1;
+}
+
+.ar-banner-heading {
+  font-family: var(--font-serif);
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--kotai-charcoal);
+  margin: 0 0 0.375rem;
+  line-height: 1.25;
+}
+
+@media (min-width: 768px) { .ar-banner-heading { font-size: 1.5rem; } }
+
+.ar-banner-body {
+  font-size: 1rem;
+  color: var(--kotai-slate);
+  margin: 0;
+  line-height: 1.55;
+}
+
+.ar-banner-btn {
+  background: var(--kotai-peach);
+  color: var(--kotai-charcoal);
+  font-weight: 700;
+  padding: 0.875rem 1.75rem;
+  border-radius: 0.75rem;
+  border: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ar-banner-btn:hover {
+  background: var(--kotai-peach-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(255, 184, 159, 0.4);
+  color: var(--kotai-charcoal);
+}
+
 /* === ASSESSMENT SECTION === */
 .ai-readiness-section {
   padding: 3rem 1rem 5rem;

--- a/frontend/styles/hero.css
+++ b/frontend/styles/hero.css
@@ -54,6 +54,24 @@
   color: white;
 }
 
+/* AI-Readiness assessment button */
+.btn-assessment-digital {
+  width: 100%;
+  height: 3.5rem;
+  padding: 0 2rem;
+  background: var(--kotai-peach);
+  color: var(--kotai-charcoal);
+  border: none;
+  font-weight: 600;
+}
+
+.btn-assessment-digital:hover {
+  background: #e8714a;
+  color: white;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  transform: translateY(-2px);
+}
+
 /* Fractional hero buttons */
 .btn-primary-fractional {
   width: 100%;
@@ -91,6 +109,7 @@
 @media (min-width: 640px) {
   .btn-primary-digital,
   .btn-secondary-digital,
+  .btn-assessment-digital,
   .btn-primary-fractional,
   .btn-secondary-fractional {
     width: auto;

--- a/frontend/styles/hero.css
+++ b/frontend/styles/hero.css
@@ -105,6 +105,53 @@
   color: white;
 }
 
+/* AI Readiness strip inside hero */
+.hero-assessment-strip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  margin: 1.75rem auto 0;
+  padding: 1.25rem 1.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1rem;
+  max-width: 820px;
+}
+
+@media (min-width: 640px) {
+  .hero-assessment-strip {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+    gap: 1.5rem;
+  }
+}
+
+.hero-assessment-text {
+  font-size: 0.9375rem;
+  color: rgba(255, 255, 255, 0.88);
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (min-width: 640px) {
+  .hero-assessment-text {
+    flex: 0 1 320px;
+  }
+}
+
+.hero-assessment-text strong {
+  color: white;
+  display: block;
+}
+
+.btn-assessment-digital {
+  white-space: nowrap;
+}
+
 /* Mobile → desktop width reset */
 @media (min-width: 640px) {
   .btn-primary-digital,

--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -5,3 +5,4 @@
 @import "kotai.css";
 @import "hero.css";
 @import "syntax-highlighting.css";
+@import "ai_readiness.css";

--- a/frontend/styles/kotai.css
+++ b/frontend/styles/kotai.css
@@ -772,21 +772,21 @@ body { padding-bottom: 5rem; }
 
 @media (min-width: 640px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 4rem;
+    padding-top: 3rem;
     padding-bottom: 3rem;
   }
 }
 
 @media (min-width: 768px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 5rem;
+    padding-top: 3rem;
     padding-bottom: 3rem;
   }
 }
 
 @media (min-width: 1024px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 6rem;
+    padding-top: 3rem;
     padding-bottom: 3rem;
   }
 }

--- a/frontend/styles/kotai.css
+++ b/frontend/styles/kotai.css
@@ -772,22 +772,22 @@ body { padding-bottom: 5rem; }
 
 @media (min-width: 640px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
+    padding-top: 3.3rem;
+    padding-bottom: 3.3rem;
   }
 }
 
 @media (min-width: 768px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
+    padding-top: 3.3rem;
+    padding-bottom: 3.3rem;
   }
 }
 
 @media (min-width: 1024px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
+    padding-top: 3.3rem;
+    padding-bottom: 3.3rem;
   }
 }
 

--- a/frontend/styles/kotai.css
+++ b/frontend/styles/kotai.css
@@ -766,27 +766,27 @@ body { padding-bottom: 5rem; }
 }
 
 .hero.is-large.hero-digital .hero-body {
-  padding-top: 5rem;
+  padding-top: 3rem;
   padding-bottom: 3rem;
 }
 
 @media (min-width: 640px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 6rem;
+    padding-top: 4rem;
     padding-bottom: 3rem;
   }
 }
 
 @media (min-width: 768px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 7rem;
+    padding-top: 5rem;
     padding-bottom: 3rem;
   }
 }
 
 @media (min-width: 1024px) {
   .hero.is-large.hero-digital .hero-body {
-    padding-top: 8rem;
+    padding-top: 6rem;
     padding-bottom: 3rem;
   }
 }

--- a/src/_components/ai_readiness_assessment.liquid
+++ b/src/_components/ai_readiness_assessment.liquid
@@ -1,0 +1,382 @@
+<!-- AI Readiness Self-Assessment Quiz -->
+<section class="ai-readiness-section">
+  <div class="ai-readiness-container">
+    <div class="ar-card">
+
+      <!-- Card Header -->
+      <div class="ar-card-header">
+        <h2>AI Readiness Self-Assessment</h2>
+        <div class="ar-header-meta">
+          <p>Time to complete: ~5 minutes</p>
+        </div>
+      </div>
+
+      <!-- Card Body -->
+      <div class="ar-card-body">
+
+        <!-- Progress meta -->
+        <div id="arMetaRow" class="ar-meta-row">
+          <span id="arSectionBadge" class="ar-badge">Section 1</span>
+          <span id="arCountText" class="ar-badge">Question 1 / 12</span>
+        </div>
+
+        <!-- Progress bar -->
+        <div id="arProgressWrap" class="ar-progress">
+          <span id="arProgressFill" class="ar-progress-fill"></span>
+        </div>
+
+        <!-- Question view -->
+        <div id="arQuestionView">
+          <p class="ar-question" id="arQuestionText"></p>
+          <div class="ar-options" id="arOptions"></div>
+          <p class="ar-hint">Choose one option, then click Next.</p>
+          <div class="ar-nav">
+            <button id="arPrevBtn" class="ar-btn ar-btn-secondary" type="button">
+              <i data-lucide="arrow-left"></i> Previous
+            </button>
+            <button id="arNextBtn" class="ar-btn ar-btn-primary" type="button">
+              Next <i data-lucide="arrow-right"></i>
+            </button>
+          </div>
+        </div>
+
+        <!-- Result view (hidden until complete) -->
+        <div id="arResultView" style="display:none;">
+          <div id="arResultCard" class="ar-result-card"></div>
+          <div class="ar-result-cta">
+            <h3>Ready to accelerate your AI journey?</h3>
+            <p>Our experts at Kotai will walk you through a personalised roadmap — tailored to your score and industry.</p>
+            <div class="ar-result-actions">
+              <a class="ar-btn ar-btn-peach" href="{{ '/contact/' | relative_url }}">
+                <i data-lucide="calendar"></i> Book a free strategy session
+              </a>
+              <button id="arRestartBtn" class="ar-btn ar-btn-secondary" type="button">
+                <i data-lucide="rotate-ccw"></i> Restart Assessment
+              </button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+(function () {
+  var sections = [
+    {
+      title: "Business Alignment",
+      max: 6,
+      questions: [
+        {
+          text: "We have a clearly defined business problem AI could help solve",
+          options: [
+            "Problem unclear or not documented.",
+            "Problem discussed, but not finalized.",
+            "Problem mostly clear with some gaps.",
+            "Problem clearly defined with business context.",
+          ],
+        },
+        {
+          text: "Success metrics for an AI initiative are clearly defined",
+          options: [
+            "No success metrics are defined.",
+            "Basic metrics exist but are not measurable.",
+            "Most success metrics are measurable.",
+            "Clear measurable KPIs are fully defined.",
+          ],
+        },
+      ],
+    },
+    {
+      title: "Process Maturity",
+      max: 6,
+      questions: [
+        {
+          text: "The process we want to improve is documented or well understood",
+          options: [
+            "Process is not documented.",
+            "Some parts are documented.",
+            "Most process steps are documented.",
+            "Process is fully documented and understood.",
+          ],
+        },
+        {
+          text: "The process runs frequently enough to justify automation",
+          options: [
+            "Process is rare; automation not useful.",
+            "Process happens occasionally.",
+            "Process is frequent in some teams.",
+            "Process is frequent and high-volume.",
+          ],
+        },
+      ],
+    },
+    {
+      title: "Data Readiness",
+      max: 6,
+      questions: [
+        {
+          text: "Relevant data already exists",
+          options: [
+            "Required data is missing.",
+            "Some required data exists.",
+            "Most required data exists.",
+            "All key data is available and usable.",
+          ],
+        },
+        {
+          text: "Data ownership and access permissions are clear",
+          options: [
+            "No clear data owner or access rules.",
+            "Ownership or access is partially defined.",
+            "Ownership and access are mostly clear.",
+            "Ownership and access control are fully clear.",
+          ],
+        },
+      ],
+    },
+    {
+      title: "Technology Readiness",
+      max: 6,
+      questions: [
+        {
+          text: "Our systems support APIs or integrations",
+          options: [
+            "Systems are isolated; no integration support.",
+            "Limited integrations are available.",
+            "Most core systems support integration.",
+            "Strong API/integration support is in place.",
+          ],
+        },
+        {
+          text: "We can support deployment and monitoring",
+          options: [
+            "No deployment/monitoring process for AI.",
+            "Basic deployment exists; monitoring is weak.",
+            "Deployment and monitoring are mostly ready.",
+            "Reliable deployment and monitoring are fully ready.",
+          ],
+        },
+      ],
+    },
+    {
+      title: "People & Change Readiness",
+      max: 6,
+      questions: [
+        {
+          text: "Leadership supports AI initiatives",
+          options: [
+            "Leadership is not aligned on AI.",
+            "Some leaders support AI informally.",
+            "Most leadership supports AI direction.",
+            "Leadership actively sponsors AI initiatives.",
+          ],
+        },
+        {
+          text: "There is a clear owner for AI initiatives",
+          options: [
+            "No owner assigned for AI work.",
+            "Temporary owner exists but unclear role.",
+            "Owner is mostly defined with responsibilities.",
+            "Clear accountable owner is fully assigned.",
+          ],
+        },
+      ],
+    },
+    {
+      title: "Risk & Governance Awareness",
+      max: 6,
+      questions: [
+        {
+          text: "We understand where human review is required",
+          options: [
+            "No clear human-review checkpoints.",
+            "Few review points are identified.",
+            "Most review points are identified.",
+            "Human-review checkpoints are clearly defined.",
+          ],
+        },
+        {
+          text: "We have guardrails for responsible AI use",
+          options: [
+            "No responsible AI guardrails exist.",
+            "Basic guidelines exist but are incomplete.",
+            "Guardrails exist for most major risks.",
+            "Strong responsible-AI guardrails are implemented.",
+          ],
+        },
+      ],
+    },
+  ];
+
+  var flatQuestions = [];
+  sections.forEach(function (section, sectionIndex) {
+    section.questions.forEach(function (question) {
+      flatQuestions.push({
+        sectionIndex: sectionIndex,
+        sectionTitle: section.title,
+        text: question.text,
+        options: question.options,
+      });
+    });
+  });
+
+  var totalQuestions = flatQuestions.length;
+  var maxScore = sections.reduce(function (sum, s) { return sum + s.max; }, 0);
+  var currentIndex = 0;
+  var answers = new Array(totalQuestions).fill(null);
+
+  var elSectionBadge  = document.getElementById("arSectionBadge");
+  var elCountText     = document.getElementById("arCountText");
+  var elMetaRow       = document.getElementById("arMetaRow");
+  var elProgressWrap  = document.getElementById("arProgressWrap");
+  var elProgressFill  = document.getElementById("arProgressFill");
+  var elQuestionText  = document.getElementById("arQuestionText");
+  var elOptions       = document.getElementById("arOptions");
+  var elQuestionView  = document.getElementById("arQuestionView");
+  var elResultView    = document.getElementById("arResultView");
+  var elResultCard    = document.getElementById("arResultCard");
+  var elPrevBtn       = document.getElementById("arPrevBtn");
+  var elNextBtn       = document.getElementById("arNextBtn");
+  var elRestartBtn    = document.getElementById("arRestartBtn");
+
+  function calculateScores() {
+    var sectionScores = sections.map(function () { return 0; });
+    var totalScore = 0;
+    answers.forEach(function (score, index) {
+      if (score !== null) {
+        sectionScores[flatQuestions[index].sectionIndex] += score;
+        totalScore += score;
+      }
+    });
+    return { sectionScores: sectionScores, totalScore: totalScore };
+  }
+
+  function renderQuestion() {
+    var question = flatQuestions[currentIndex];
+    var progress = ((currentIndex + 1) / totalQuestions) * 100;
+    var selectedAnswer = answers[currentIndex];
+
+    elSectionBadge.textContent = "Section " + (question.sectionIndex + 1) + ": " + question.sectionTitle;
+    elCountText.textContent = "Question " + (currentIndex + 1) + " / " + totalQuestions;
+    elProgressFill.style.width = progress + "%";
+    elQuestionText.textContent = question.text;
+
+    elOptions.innerHTML = "";
+    question.options.forEach(function (optionText, score) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "ar-option-btn" + (selectedAnswer === score ? " selected" : "");
+      btn.innerHTML =
+        "<span class='ar-option-score'>" + score + "/3</span>" +
+        "<span class='ar-option-content'>" +
+          "<span class='ar-option-text'>" + optionText + "</span>" +
+        "</span>";
+      btn.addEventListener("click", function () { handleAnswer(score); });
+      elOptions.appendChild(btn);
+    });
+
+    // Re-render lucide icons inside new buttons
+    if (window.lucide) { lucide.createIcons(); }
+
+    elPrevBtn.disabled = currentIndex === 0;
+    elNextBtn.disabled = selectedAnswer === null;
+    elNextBtn.innerHTML = currentIndex === totalQuestions - 1
+      ? "Finish <i data-lucide=\"check\"></i>"
+      : "Next <i data-lucide=\"arrow-right\"></i>";
+    if (window.lucide) { lucide.createIcons(); }
+  }
+
+  function handleAnswer(score) {
+    answers[currentIndex] = score;
+    if (currentIndex >= totalQuestions - 1) {
+      renderResult();
+      return;
+    }
+    currentIndex += 1;
+    renderQuestion();
+  }
+
+  function scoreMessage(score) {
+    if (score >= 28) {
+      return {
+        title: "AI Ready",
+        nextStep: "Identify 1–2 high-ROI use cases and start building.",
+        text: "You are well-positioned to move directly into a pilot or production AI initiative.",
+        className: "ar-result-ready",
+      };
+    }
+    if (score >= 19) {
+      return {
+        title: "AI Emerging",
+        nextStep: "Run an AI discovery or readiness workshop.",
+        text: "You have strong foundations but gaps in clarity, data, or execution.",
+        className: "ar-result-emerging",
+      };
+    }
+    return {
+      title: "AI Exploration Stage",
+      nextStep: "Focus on process clarity, data access, and education.",
+      text: "AI could add value, but fundamentals need work first.",
+      className: "ar-result-explore",
+    };
+  }
+
+  function renderResult() {
+    var scores = calculateScores();
+    var result = scoreMessage(scores.totalScore);
+
+    elQuestionView.style.display = "none";
+    elResultView.style.display = "block";
+    elMetaRow.style.display = "none";
+    elProgressWrap.style.display = "none";
+
+    elResultCard.className = "ar-result-card " + result.className;
+
+    var sectionHtml = "<div class='ar-section-scores'><strong>Section Scores</strong><ul>";
+    sections.forEach(function (section, index) {
+      sectionHtml += "<li><span>" + section.title + "</span><strong>" + scores.sectionScores[index] + " / " + section.max + "</strong></li>";
+    });
+    sectionHtml += "</ul></div>";
+
+    elResultCard.innerHTML =
+      "<p class='ar-result-status-badge'>Assessment Complete</p>" +
+      "<div class='ar-score-line'>" +
+        "<span class='ar-score-label'>Your Total AI Readiness Score</span>" +
+        "<span class='ar-score-value'>" + scores.totalScore + " / " + maxScore + "</span>" +
+      "</div>" +
+      "<h2>" + result.title + "</h2>" +
+      "<p>" + result.text + "</p>" +
+      "<p><strong>Next step:</strong> " + result.nextStep + "</p>" +
+      sectionHtml;
+
+    // Scroll card into view
+    elResultCard.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  elPrevBtn.addEventListener("click", function () {
+    if (currentIndex > 0) { currentIndex -= 1; renderQuestion(); }
+  });
+
+  elNextBtn.addEventListener("click", function () {
+    if (answers[currentIndex] === null) return;
+    if (currentIndex >= totalQuestions - 1) { renderResult(); return; }
+    currentIndex += 1;
+    renderQuestion();
+  });
+
+  elRestartBtn.addEventListener("click", function () {
+    currentIndex = 0;
+    answers = new Array(totalQuestions).fill(null);
+    elQuestionView.style.display = "block";
+    elResultView.style.display = "none";
+    elMetaRow.style.display = "flex";
+    elProgressWrap.style.display = "block";
+    renderQuestion();
+  });
+
+  renderQuestion();
+})();
+</script>

--- a/src/_components/ai_readiness_assessment.liquid
+++ b/src/_components/ai_readiness_assessment.liquid
@@ -29,13 +29,10 @@
         <div id="arQuestionView">
           <p class="ar-question" id="arQuestionText"></p>
           <div class="ar-options" id="arOptions"></div>
-          <p class="ar-hint">Choose one option, then click Next.</p>
+          <p class="ar-hint">Choose one option above. If you want to change your answer, click Previous.</p>
           <div class="ar-nav">
             <button id="arPrevBtn" class="ar-btn ar-btn-secondary" type="button">
               <i data-lucide="arrow-left"></i> Previous
-            </button>
-            <button id="arNextBtn" class="ar-btn ar-btn-primary" type="button">
-              Next <i data-lucide="arrow-right"></i>
             </button>
           </div>
         </div>
@@ -239,7 +236,6 @@
   var elResultView    = document.getElementById("arResultView");
   var elResultCard    = document.getElementById("arResultCard");
   var elPrevBtn       = document.getElementById("arPrevBtn");
-  var elNextBtn       = document.getElementById("arNextBtn");
   var elRestartBtn    = document.getElementById("arRestartBtn");
 
   function calculateScores() {
@@ -282,10 +278,6 @@
     if (window.lucide) { lucide.createIcons(); }
 
     elPrevBtn.disabled = currentIndex === 0;
-    elNextBtn.disabled = selectedAnswer === null;
-    elNextBtn.innerHTML = currentIndex === totalQuestions - 1
-      ? "Finish <i data-lucide=\"check\"></i>"
-      : "Next <i data-lucide=\"arrow-right\"></i>";
     if (window.lucide) { lucide.createIcons(); }
   }
 
@@ -358,13 +350,6 @@
 
   elPrevBtn.addEventListener("click", function () {
     if (currentIndex > 0) { currentIndex -= 1; renderQuestion(); }
-  });
-
-  elNextBtn.addEventListener("click", function () {
-    if (answers[currentIndex] === null) return;
-    if (currentIndex >= totalQuestions - 1) { renderResult(); return; }
-    currentIndex += 1;
-    renderQuestion();
   });
 
   elRestartBtn.addEventListener("click", function () {

--- a/src/_components/ai_readiness_banner.liquid
+++ b/src/_components/ai_readiness_banner.liquid
@@ -1,0 +1,16 @@
+<!-- AI Readiness Self-Assessment Banner -->
+<section class="ar-banner">
+  <div class="ar-banner-inner">
+    <div class="ar-banner-icon">
+      <i data-lucide="sparkles"></i>
+    </div>
+    <div class="ar-banner-content">
+      <h2 class="ar-banner-heading">Are you ready to adopt AI?</h2>
+      <p class="ar-banner-body">Take our 5-minute self assessment to see your AI maturity.</p>
+    </div>
+    <a href="{{ '/ai-readiness/' | relative_url }}" class="btn ar-banner-btn">
+      <i data-lucide="sparkles" class="btn-icon"></i>
+      AI Readiness Self-Assessment
+    </a>
+  </div>
+</section>

--- a/src/_components/ai_readiness_hero.liquid
+++ b/src/_components/ai_readiness_hero.liquid
@@ -1,0 +1,28 @@
+<!-- AI Readiness Self-Assessment Hero -->
+<section class="ai-readiness-hero">
+  <div class="ai-readiness-hero-inner">
+    <div class="ai-readiness-badge">
+      <i data-lucide="sparkles" class="ai-readiness-badge-icon"></i>
+      <span>Free Self-Assessment Tool</span>
+    </div>
+    <h1>AI Readiness<br>Self-Assessment</h1>
+    <p>
+      Find out how prepared your organization is to adopt AI across strategy, data, technology, execution and culture.
+      <br><small>Takes about 5 minutes. No sign-up required.</small>
+    </p>
+    <div class="ai-readiness-hero-meta">
+      <span class="ai-readiness-meta-item">
+        <i data-lucide="clock"></i>
+        ~5 minutes
+      </span>
+      <span class="ai-readiness-meta-item">
+        <i data-lucide="list-checks"></i>
+        12 questions across 6 dimensions
+      </span>
+      <span class="ai-readiness-meta-item">
+        <i data-lucide="shield-check"></i>
+        Instant personalized results
+      </span>
+    </div>
+  </div>
+</section>

--- a/src/_components/contact_form.liquid
+++ b/src/_components/contact_form.liquid
@@ -83,6 +83,7 @@
             <select id="contact-service" name="service" required>
               <option value="">Select a service</option>
               <option value="digital">Kotai Digital</option>
+              <option value="ai-strategy">AI Strategy</option>
               <!-- TODO: Uncomment to bring back Fractional page/sections -->
               <!-- <option value="fractional">Kotai Fractional</option> -->
               <!-- <option value="both">Both</option> -->

--- a/src/_components/cta_section.liquid
+++ b/src/_components/cta_section.liquid
@@ -7,6 +7,6 @@
     {% endif %}
     <h2{% if title_id %} id="{{ title_id }}"{% endif %}>{{ title }}</h2>
     <p{% if body_id %} id="{{ body_id }}"{% endif %}>{{ body }}</p>
-    <a href="{{ button_href }}" class="btn btn-cta">{{ button_text }}</a>
+    <a href="{{ button_href }}" class="btn btn-cta">{% if button_icon %}<i data-lucide="{{ button_icon }}" class="btn-icon"></i> {% endif %}{{ button_text }}</a>
   </div>
 </section>

--- a/src/_components/hero_digital.liquid
+++ b/src/_components/hero_digital.liquid
@@ -21,6 +21,9 @@
         <a href="{{ '/services/' | relative_url }}" class="btn btn-secondary-digital">
           <i data-lucide="workflow" class="btn-icon"></i> View Capabilities
         </a>
+        <a href="{{ '/ai-readiness/' | relative_url }}" class="btn btn-assessment-digital">
+          <i data-lucide="sparkles" class="btn-icon"></i> AI-Readiness Self-Assessment
+        </a>
       </div>
 
       <!-- Feature mini-cards -->

--- a/src/_components/hero_digital.liquid
+++ b/src/_components/hero_digital.liquid
@@ -3,10 +3,6 @@
   <div class="hero-grid-pattern"></div>
   <div class="hero-body">
     <div class="container has-text-centered">
-      <div class="hero-badge mb-5">
-        <i data-lucide="zap" class="badge-icon"></i>
-        <span>AI-first Product &amp; Process Innovation</span>
-      </div>
       <h1 class="title is-1 mb-4">
         You are busy building your business.<br>
         <span class="hero-title-tagline highlight-peach">Trust us with building your software platform.</span>

--- a/src/_components/hero_digital.liquid
+++ b/src/_components/hero_digital.liquid
@@ -21,8 +21,12 @@
         <a href="{{ '/services/' | relative_url }}" class="btn btn-secondary-digital">
           <i data-lucide="workflow" class="btn-icon"></i> View Capabilities
         </a>
+      </div>
+
+      <div class="hero-assessment-strip">
+        <p class="hero-assessment-text"><strong>Are you ready to adopt AI?</strong><br>Take our 5-minute self assessment to see your company's AI maturity score.</p>
         <a href="{{ '/ai-readiness/' | relative_url }}" class="btn btn-assessment-digital">
-          <i data-lucide="sparkles" class="btn-icon"></i> AI-Readiness Self-Assessment
+          <i data-lucide="sparkles" class="btn-icon"></i> AI Readiness Self-Assessment
         </a>
       </div>
 

--- a/src/_components/mobile_bottom_bar.liquid
+++ b/src/_components/mobile_bottom_bar.liquid
@@ -1,15 +1,15 @@
+<!-- TODO: Uncomment to bring back Fractional page/sections -->
+<!--
 <div class="mobile-bottom-bar" id="mobileBottomBar">
   <div class="bottom-bar-container">
     <button id="bottomToggleDigital" class="bottom-toggle-btn active" data-mode="digital">
       <span class="bottom-toggle-bg"></span>
       <span class="bottom-toggle-text">Digital</span>
     </button>
-    <!-- TODO: Uncomment to bring back Fractional page/sections -->
-    <!--
     <button id="bottomToggleFractional" class="bottom-toggle-btn" data-mode="fractional">
       <span class="bottom-toggle-bg"></span>
       <span class="bottom-toggle-text">Fractional</span>
     </button>
-    -->
   </div>
 </div>
+-->

--- a/src/_layouts/ai_readiness.liquid
+++ b/src/_layouts/ai_readiness.liquid
@@ -1,0 +1,14 @@
+---
+layout: default
+page_id: ai-readiness
+---
+{% render "ai_readiness_hero" %}
+{% render "ai_readiness_assessment" %}
+{% render "cta_section",
+   title: "Let's Build Your AI Roadmap",
+   body: "Our team will walk you through a personalised strategy grounded in your AI readiness assessment results and your industry.",
+   button_text: "Book a Free Strategy Session",
+   button_href: "/contact/",
+   button_icon: "calendar",
+   icon: "sparkles",
+   extra_class: "cta-digital" %}

--- a/src/ai-readiness.md
+++ b/src/ai-readiness.md
@@ -1,0 +1,6 @@
+---
+layout: ai_readiness
+title: AI-Readiness Self-Assessment
+page_id: ai-readiness
+permalink: /ai-readiness/
+---


### PR DESCRIPTION
## Summary

- Adds a new interactive **AI Readiness Self-Assessment** page at `/ai-readiness/` with a 12-question quiz across 6 dimensions (business alignment, process maturity, data readiness, technology readiness, people & change, risk & governance)
- Scores users into three tiers — AI Ready, AI Emerging, AI Exploration Stage — with a styled result card and CTA to book a strategy session
- Adds a peach-themed **AI-Readiness Self-Assessment** CTA button to the Digital hero
- Adds **AI Strategy** to the Contact Us service dropdown
- Adds a coding spec for future email integration on the Contact Us form

## Changes

- `src/ai-readiness.md` — new page at `/ai-readiness/`
- `src/_layouts/ai_readiness.liquid` — layout composing hero, quiz, and CTA section
- `src/_components/ai_readiness_hero.liquid` — hero with sparkles badge and meta stats
- `src/_components/ai_readiness_assessment.liquid` — full interactive quiz with scoring and results
- `frontend/styles/ai_readiness.css` — all styles adapted to site palette (peach, slate, charcoal)
- `frontend/styles/hero.css` — peach assessment CTA button styles
- `frontend/styles/index.css` — imports `ai_readiness.css`
- `src/_components/hero_digital.liquid` — AI Readiness button added to hero CTA group
- `src/_components/cta_section.liquid` — optional `button_icon` parameter added
- `src/_components/contact_form.liquid` — AI Strategy option added to service dropdown
- `.features/email-integration/CODING-SPEC-email-integration.md` — spec for Contact Us email integration

## Test plan

- [ ] Visit `/ai-readiness/` and verify hero, quiz card, and CTA section render correctly
- [ ] Complete the quiz and verify result card shows correct tier, score, and section breakdown
- [ ] Confirm "ASSESSMENT COMPLETE" badge color matches result tier (green / orange / red)
- [ ] Verify the AI Readiness button appears in the Digital hero
- [ ] Confirm AI Strategy appears in the Contact Us service dropdown
- [ ] Check mobile layout of quiz card and hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)